### PR TITLE
Upgrade to current version of @google-cloud/storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const storage = require('@google-cloud/storage');
+const {Storage} = require('@google-cloud/storage');
 
 function getLastModified(file) {
   return file.getMetadata().then(([{timeCreated}]) => timeCreated);
@@ -32,7 +32,7 @@ class GCSNotifier {
   }
 
   subscribe(notify) {
-    const file = storage(this.authentication).bucket(this.bucket).file(this.key);
+    const file = new Storage(this.authentication).bucket(this.bucket).file(this.key);
 
     return getLastModified(file).then((lastModified) => {
       schedulePoll(this.pollTime, lastModified, this.ui, file, notify);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-gcs-notifier",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A FastBoot App Server notifier for Google Cloud Storage",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "eslint ."
   },
   "dependencies": {
-    "@google-cloud/storage": "^0.4.0"
+    "@google-cloud/storage": "^2.3.0"
   },
   "devDependencies": {
     "eslint": "^3.9.1",


### PR DESCRIPTION
Prompted by wanting to get the downstream dependency on `grpc` to a high enough version that precompiled binaries are available for Node 10.13 LTS.